### PR TITLE
fix: set lock on state root handling directly

### DIFF
--- a/chains/evm/listener/handlers/deposit.go
+++ b/chains/evm/listener/handlers/deposit.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"slices"
 	"strings"
-	"sync"
 
 	ethereumABI "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -56,7 +55,6 @@ type DepositEventHandler struct {
 	slotIndex        uint8
 	genericResources []string
 	msgChan          chan []*message.Message
-	lock             sync.Mutex
 }
 
 func NewDepositEventHandler(
@@ -76,14 +74,10 @@ func NewDepositEventHandler(
 		genericResources: genericResources,
 		msgChan:          msgChan,
 		domainID:         domainID,
-		lock:             sync.Mutex{},
 	}
 }
 
 func (h *DepositEventHandler) HandleEvents(destination uint8, startBlock *big.Int, endBlock *big.Int, slot *big.Int) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
 	deposits, err := h.fetchDeposits(destination, startBlock, endBlock)
 	if err != nil {
 		return err

--- a/chains/evm/listener/handlers/hashi.go
+++ b/chains/evm/listener/handlers/hashi.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"sync"
 
 	"github.com/attestantio/go-eth2-client/api"
 	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -54,7 +53,6 @@ type HashiEventHandler struct {
 	beaconClient  BeaconClient
 	client        Client
 	chainIDS      map[uint8]uint64
-	lock          sync.Mutex
 }
 
 func NewHashiEventHandler(
@@ -78,14 +76,10 @@ func NewHashiEventHandler(
 		rootProver:    rootProver,
 		chainIDS:      chainIDS,
 		msgChan:       msgChan,
-		lock:          sync.Mutex{},
 	}
 }
 
 func (h *HashiEventHandler) HandleEvents(destination uint8, startBlock *big.Int, endBlock *big.Int, slot *big.Int) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
 	logs, err := h.fetchMessages(startBlock, endBlock)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->
The specific locks don't work as they always queue with the same block range. 
The lock should be on state root handling as that is was dictates the block range on which it operates.

Closes: #<issue>

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
