### PR TITLE
chore: updated organisation name to sprinter

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -38,7 +38,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v4
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -73,7 +73,7 @@ jobs:
       - name: checkout ecs repo
         uses: actions/checkout@v4
         with:
-          repository: sygmaprotocol/devops
+          repository: sprintertech/devops
           token: ${{ secrets.GHCR_TOKEN }}
 
       - name: render jinja2 templates to task definition json files

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY --from=builder /inclusion-prover ./
 RUN chmod +x ./inclusion-prover
 RUN mkdir -p /mount
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-LABEL org.opencontainers.image.source https://github.com/sygmaprotocol/sygma-inclusion-prover
+LABEL org.opencontainers.image.source https://github.com/sprintertech/sygma-inclusion-prover
 ENTRYPOINT ["./inclusion-prover"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 
 services:
   beacon-stub:
-    image: ghcr.io/sygmaprotocol/beacon-api-stub
+    image: ghcr.io/sprintertech/beacon-api-stub
     volumes:
       - "./stubs:/stubs"
     ports:
@@ -13,13 +13,13 @@ services:
       - STUB_DATA=/stubs/beacon.yml
 
   evm1:
-    image: ghcr.io/sygmaprotocol/sygma-x-solidity:1
+    image: ghcr.io/sprintertech/sygma-x-solidity:1
     container_name: evm1
     command: "--db data/ -h 0.0.0.0 -p 8545 --wallet.mnemonic 'myth like bonus scare over problem client lizard pioneer submit female collect'"
     ports:
       - "8545:8545"
   evm2:
-    image: ghcr.io/sygmaprotocol/sygma-x-solidity:2
+    image: ghcr.io/sprintertech/sygma-x-solidity:2
     command: "--db data/ -h 0.0.0.0 -p 8545 --wallet.mnemonic 'myth like bonus scare over problem client lizard pioneer submit female collect'"
     container_name: evm2
     ports:


### PR DESCRIPTION
## GitHub Organisation Name Change from Sygmaprotocol to Sprintertech

## Description
Updated the GitHub name to sprintertech

## Related Issue Or Context

Related: #[issues 588](https://github.com/sprintertech/devops/issues/588#issue-2784021910)